### PR TITLE
fix instant alert button

### DIFF
--- a/templates/concept.html
+++ b/templates/concept.html
@@ -50,7 +50,7 @@
 				<div class="o-grid-row o-grid-row--compact">
 					<div data-o-grid-colspan="7 M12 XL7">
 						{{#if @root.flags.myFTInstantAlertsButtons}}
-							{{> n-ui/myft/templates/instant-alert conceptId=conceptId name=name taxonomy=taxonomy extraClasses="card__concept-instant" }}
+							{{> n-ui/myft/templates/instant-alert conceptId=id name=name taxonomy=taxonomy extraClasses="card__concept-instant" }}
 						{{/if}}
 					</div>
 					<div data-o-grid-colspan="5 M12 XL5">


### PR DESCRIPTION
the "save" button works, the "instant alert" button doesn't - it seems that "save" uses `id` whereas "instant alert" uses `conceptId`

so I've changed "instant alert" to use `id` instead of `conceptId`.