### PR TITLE
Larger arrow bullet-point icons

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -28,11 +28,11 @@
 	font: 16px/1.3 Georgia, serif;
 
 	&:before {
-		@include oIconsGetIcon('arrow-right', oColorsGetColorFor('myft'), 10);
+		@include oIconsGetIcon('arrow-right', oColorsGetColorFor('myft'), 20);
 		content: '';
-		left: 0;
 		position: absolute;
-		top: 4px;
+		top: 0;
+		left: -5px;
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "eslint": "^3.8.1",
+    "handlebars": "^4.0.6",
+    "handlebars-loader": "^1.4.0",
     "lintspaces-cli": "^0.4.0",
     "mocha": "^3.1.2",
     "node-sass": "^3.13.0",


### PR DESCRIPTION
Due to v5 o-icons

From

![screen shot 2016-12-12 at 15 48 49](https://cloud.githubusercontent.com/assets/74132/21105617/c9948ffa-c082-11e6-90a0-955e6cc7ad22.jpeg)

To

![screen shot 2016-12-12 at 15 50 27](https://cloud.githubusercontent.com/assets/74132/21105621/cc34fde4-c082-11e6-975b-88263852c102.jpeg)
