### PR TITLE
Remove: Hidden 'Actions for' screen-reader text

### DIFF
--- a/templates/concept.html
+++ b/templates/concept.html
@@ -44,7 +44,6 @@
 				<p class="card__concept-empty">To see previous articles visit the <a class="card__concept-empty-link" data-trackable="empty-link" href={{url}}>{{name}}</a> topic page</p>
 			</div>
 		{{/if}}
-		<h4 class="n-util-visually-hidden">Actions for {{name}}</h4>
 		{{#ifAll flags flags.myFtApiWrite}}
 			<div class="card__myft-meta">
 				<div class="o-grid-row o-grid-row--compact">


### PR DESCRIPTION
cc @lc512k 

Addresses part of: https://github.com/Financial-Times/next-myft-page/issues/1033.

Likewise removed in `n-card`: https://github.com/Financial-Times/n-card/pull/226.