### PR TITLE
Amend: enable new data model image properties

### DIFF
--- a/presenters/concept-image.js
+++ b/presenters/concept-image.js
@@ -23,9 +23,13 @@ class ConceptImagePresenter {
 			return taxonomyImages.default;
 		}
 		const findItemImage = this.data.items.find( item => {
-			return item.primaryImage && item.primaryImage.rawSrc && !item.isPodcast;
+			return ((item.primaryImage && item.primaryImage.rawSrc)
+				|| (item.mainImage && item.mainImage.url))
+				&& !item.isPodcast;
 		});
-		const conceptImage = findItemImage && findItemImage.primaryImage.rawSrc;
+		const conceptImage = findItemImage
+			&& ((findItemImage.primaryImage && findItemImage.primaryImage.rawSrc)
+			|| findItemImage.mainImage.url);
 
 		return conceptImage || taxonomyImages[this.data.taxonomy] || taxonomyImages.default;
 	}


### PR DESCRIPTION
New data model for content has image as mainImage.url rather than primaryImage.rawSrc.

This fix enables either new or old to be used, with hope that old will be deprecated.

