### PR TITLE
Amend: require n card

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,7 @@
     "o-grid": "^4.2.3",
     "o-tracking": "^1.1.15",
     "n-ui": "^2.52.3",
+    "n-card": "^6.8.2",
     "n-image": "^4.9.0"
-  },
-  "devDependencies": {
-    "n-card": "^6.8.2"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,5 @@
+@import 'n-card/main';
+
 .card__concept-link {
 	@include oColorsFor(topic, text);
 	border-bottom: 0;

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,3 @@
-/* for now, we must also have n-card in our apps for the css */
 .card__concept-link {
 	@include oColorsFor(topic, text);
 	border-bottom: 0;


### PR DESCRIPTION
Moving n-card to be a full dependency rather than assumed that consuming app will require it as we seek to deprecate full n-card / n-section usage.
