### PR TITLE
Amend: directly add in n-card styles and stop requiring the bloat

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,10 +10,10 @@
     "tests"
   ],
   "dependencies": {
+    "o-card": "^2.0.0",
     "o-grid": "^4.2.3",
     "o-tracking": "^1.1.15",
     "n-ui": "^2.52.3",
-    "n-card": "^6.8.2",
     "n-image": "^4.9.0"
   }
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -6,4 +6,4 @@
 );
 
 @import 'n-ui/bootstrap';
-@import 'n-card/main';
+@import '../../main';

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,5 @@
 @import 'o-card/main';
+@import 'n-image/main';
 @import './styles/card';
 @import './styles/classifier';
 @import './styles/concept';

--- a/styles/_card.scss
+++ b/styles/_card.scss
@@ -1,0 +1,264 @@
+@import './colours';
+@import './mixins';
+
+$rule-size: 1px;
+
+.card {
+	@include oCard;
+	position: relative;
+	background-color: transparent;
+	width: auto;
+	margin-top: oGridGutter();
+	padding-bottom: oGridGutter();
+	flex: 1 1 auto;
+	-ms-flex-preferred-size: auto;
+	overflow: visible;
+
+	@include oGridRespondTo(M) {
+		margin-top: oGridGutter(M);
+	}
+
+	&[data-show~="false"] {
+		display: none;
+	}
+
+	&[data-o-grid-colspan^="0"] {
+		@include oGridRespondTo($until: S) {
+			display: none;
+		}
+	}
+
+	&[data-o-grid-colspan~="S0"] {
+		@include oGridRespondTo(S, $until: M) {
+			display: none;
+		}
+	}
+
+	&[data-o-grid-colspan~="M0"] {
+		@include oGridRespondTo(M, $until: L) {
+			display: none;
+		}
+	}
+
+	&[data-o-grid-colspan~="L0"] {
+		@include oGridRespondTo(L, $until: XL) {
+			display: none;
+		}
+	}
+
+	&[data-o-grid-colspan~="XL0"] {
+		@include oGridRespondTo(XL) {
+			display: none;
+		}
+	}
+
+	// top rule (horizontal line)
+	&:before {
+		content: '';
+		position: absolute;
+		height: $rule-size;
+		left: 0;
+		right: 0;
+		top: -$rule-size;
+		background-color: oColorsGetColorFor(card, border);
+	}
+
+	// left rule (vertical line)
+	&:after {
+		content: '';
+		position: absolute;
+		width: $rule-size;
+		top: 0px;
+		bottom: oGridGutter() / -2;
+		left: oGridGutter() / -2;
+		background-color: oColorsGetColorFor(card, border);
+
+		@include oGridRespondTo(M) {
+			top: 0px;
+			bottom: oGridGutter(M) / -2;
+			left: oGridGutter(M) / -2;
+		}
+	}
+
+	&[data-image~="left"],
+	&[data-image~="right"] {
+		@include oCardThemeLandscape;
+
+		// IE9 hack to prevent articles not clearing floated content
+		.card__content--clear-floats {
+			clear: both;
+		}
+	}
+
+	@each $layout-name in $_o-grid-layout-names {
+		@include oGridRespondTo($layout-name) {
+			&[data-show~="#{$layout-name}--true"] {
+				@include displayFlex;
+			}
+
+			&[data-show~="#{$layout-name}--false"] {
+				display: none;
+			}
+
+			&[data-image~="#{$layout-name}--left"],
+			&[data-image~="#{$layout-name}--right"] {
+				@include oCardThemeLandscape;
+
+				// IE9 hack to prevent articles not clearing floated content
+				.card__content--clear-floats {
+					clear: both;
+				}
+			}
+
+			&[data-image~="#{$layout-name}--top"],
+			&[data-image~="#{$layout-name}--bottom"] {
+				@include oCardThemePortrait;
+			}
+		}
+	}
+}
+
+.card--article {
+	min-height: 1px; // IE fix
+}
+
+.card--main,
+.card--picture-story {
+	@include oCardThemeStandout;
+}
+
+.card.card--paid-post,
+.card.card--promoted-content,
+.card.card--smartmatch {
+	.card__content {
+		// HACK: This is to line up the paid post's title with the story next to it
+		background-color: getColor('white');
+		padding: 10px;
+		margin: 16px -10px -10px;
+	}
+}
+
+.card--external-content .card__content:after {
+	@include oIconsGetIcon('outside-page', null, 20, $iconset-version: 1);
+	content: '';
+	position: absolute;
+	bottom: 15px;
+	right: 15px;
+}
+
+.card--editors-pick {
+	@include oColorsFor(card-editors-pick, background);
+	position: relative;
+
+	&:before {
+		position: absolute;
+		top: 0;
+		left: auto;
+		right: 0;
+		width: 50px;
+		height: 55px;
+		z-index: 1;
+		background: url('https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fbackgrounds%2Ffold-with-bg-1.svg?source=next') no-repeat;
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fbackgrounds%2Ffold-with-bg-1.svg?source=next&format=png&width=50')\9;
+	}
+}
+
+.card__content {
+	@include oCardContent;
+
+	.card--editors-pick & {
+		padding-right: 40px;
+	}
+
+	.card[data-image~="left"] & {
+		margin-left: 40%;
+		padding-left: 10px;
+		width: 60%;
+
+		&.card__content--has-portrait-image {
+			.core & {
+				margin-left: 0;
+			}
+		}
+	}
+
+	.card[data-image~="hide"] & {
+		width: 100%;
+	}
+
+	@each $layout-name in $_o-grid-layout-names {
+		@include oGridRespondTo($layout-name) {
+			.card[data-image~="#{$layout-name}--left"] & {
+				margin-left: 40%;
+				padding-left: 10px;
+				width: 60%;
+
+				&.card__content--has-portrait-image {
+					.core & {
+						margin-left: 0;
+					}
+				}
+			}
+
+			.card[data-image~="#{$layout-name}--right"] &,
+			.card[data-image~="#{$layout-name}--top"] &,
+			.card[data-image~="#{$layout-name}--bottom"] &,
+			.card[data-image~="#{$layout-name}--hide"] & {
+				width: 100%;
+				margin-left: 0;
+				padding-left: 0;
+			}
+		}
+	}
+
+	.enhanced &.card__content--image-overlay {
+		@include oGridRespondTo(M) {
+			position: absolute;
+			top: 10px;
+			left: 10px;
+			right: 10px;
+			width: auto;
+			padding: 30px;
+			background-color: rgba(0, 0, 0, 0.25);
+			background: linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+			pointer-events: none;
+		}
+	}
+
+	.core .card--lazy-loading-images & {
+		width: 100%;
+		margin-left: 0;
+		padding-left: 0;
+	}
+}
+
+.card[data-image~="embedded"] {
+	.card__sub-content {
+		position: relative;
+	}
+
+	.card__image-link {
+		float: left;
+		width: 30%;
+		margin-top: 0;
+	}
+
+	.card__right-content {
+		margin-left: calc(30% + 10px);
+		margin-top: 10px;
+	}
+
+	.core &.card--lazy-loading-images .card__right-content {
+		margin-left: 0;
+	}
+}
+
+.card__content--grow {
+	flex-grow: 1;
+}
+
+.card .n-myft-ui--save {
+	display: inline-block;
+	float: right;
+	margin-bottom: 1em;
+}

--- a/styles/_classifier.scss
+++ b/styles/_classifier.scss
@@ -1,0 +1,29 @@
+.card__classifier-gap:after {
+	content: ' ';
+	margin-right: 0.11em;
+}
+
+.card__classifier {
+	@include oTypographySansBold('s', $load-progressively: true);
+
+	vertical-align: 5%;
+	padding: 0.1em 0.4em 0.14em;
+	background-color: getColor(cold-2);
+	color: #ffffff;
+	display: inline;
+
+	.card--article[data-size='large'] & {
+		vertical-align: 12%;
+	}
+
+	.card__classifier-gap ~ & { // overrides oTypographySansBold's setting
+		line-height: 15px;
+		font-size: 15px;
+
+		.card__related-item &,
+		.card__concept-article & {
+			line-height: 12px;
+			font-size: 12px;
+		}
+	}
+}

--- a/styles/_colours.scss
+++ b/styles/_colours.scss
@@ -1,0 +1,14 @@
+// colours
+@include oColorsSetColor('author-background', #d0e2e7);
+@include oColorsSetColor('author-text', #416e92);
+@include oColorsSetColor('live-blog-closed', oColorsGetPaletteColor('grey-tint4'));
+@include oColorsSetColor('live-blog-coming-soon', #fd9d00);
+@include oColorsSetColor('live-blog-in-progress', oColorsGetPaletteColor('red'));
+@include oColorsSetColor('video-card-background', #252830);
+
+// use cases
+@include oColorsSetUseCase(author, text, 'author-text');
+@include oColorsSetUseCase(card, border, 'warm-3');
+@include oColorsSetUseCase(card-editors-pick, background, 'warm-1');
+@include oColorsSetUseCase(card-video, background, 'video-card-background');
+@include oColorsSetUseCase(related-story, background, 'pink-tint1');

--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -1,8 +1,5 @@
-@import 'o-card/main';
-@import './styles/card';
-@import './styles/classifier';
-@import './styles/concept';
-@import './styles/myft-card';
+@import './colours';
+@import './mixins';
 
 .card__concept-link {
 	@include oColorsFor(topic, text);
@@ -33,17 +30,17 @@
 	font: 16px/1.3 Georgia, serif;
 
 	&:before {
-		@include oIconsGetIcon('arrow-right', oColorsGetColorFor('myft'), 20);
+		@include oIconsGetIcon('arrow-right', getColorFor('myft'), 10);
 		content: '';
+		left: 0;
 		position: absolute;
-		top: -1px;
-		left: -5px;
+		top: 4px;
 	}
 }
 
 .card__concept-article-link {
 	border-bottom-width: 0;
-	color: oColorsGetPaletteColor('cold-1');
+	color: getColor('cold-1');
 }
 
 .card__concept-article-text {

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -1,0 +1,22 @@
+@mixin displayFlex() {
+	display: block;
+
+	// Prevents autoprefixer from outputting display: -webkit-box;, which is buggy
+	& {
+		// scss-lint:disable VendorPrefix
+		/*autoprefixer: off*/
+		display: -webkit-flex;
+		display: -ms-flexbox;
+		display: flex;
+	}
+}
+
+@mixin respondTo($from: false, $until: false) {
+	@if $from == default and $until == false {
+		@content;
+	} @else {
+		@include oGridRespondTo($from, $until) {
+			@content;
+		}
+	}
+}

--- a/styles/_myft-card.scss
+++ b/styles/_myft-card.scss
@@ -1,0 +1,80 @@
+@import './colours';
+@import './mixins';
+
+.card--myft {
+	background: mix(getColorFor('myft'), getColorFor('page', background), 4%);
+	border-bottom: 1px solid getColorFor('myft');
+
+	&:before,
+	&:after {
+		display: none;
+	}
+}
+
+.card__myft-header {
+	min-height: 51px;
+	overflow: hidden;
+	padding: 0 0 10px 90px;
+
+	.card--empty &,
+	.core .card--lazy-loading-images & {
+		padding-left: 0;
+		min-height: 0;
+	}
+}
+
+.card__myft-image-container {
+	left: 10px;
+	position: absolute;
+	top: 10px;
+	width: 90px;
+	height: 51px;
+	overflow-y: hidden;
+	padding-bottom: 10px;
+	text-align: center;
+
+	&.n-image {
+		max-height: 100%;
+	}
+}
+
+.card__myft-image {
+	display: block;
+}
+
+.card__myft-title {
+	@include oTypographySansBold(m, $load-progressively: true);
+	margin: 0 0 0 10px;
+
+	.card--empty &,
+	.core .card--lazy-loading-images & {
+		margin-left: 0;
+	}
+}
+
+.card__myft-content {
+	border-top: 1px solid rgba(getColorFor('myft'), 0.3);
+	flex-grow: 1;
+	margin: 0;
+}
+
+.card__myft-meta {
+	border-top: 1px solid rgba(getColorFor('myft'), 0.3);
+	margin-top: 10px;
+	overflow: hidden;
+	padding-top: 10px;
+}
+
+
+@include oGridRespondTo($from: XL) {
+	.card__myft-header {
+		padding-left: 120px;
+		min-height: 67px;
+	}
+	.card__myft-image-container {
+		width: 120px;
+		height: 67px;
+		padding-bottom: 10px;
+		text-align: center;
+	}
+}


### PR DESCRIPTION
cc: @debugwand 

Bringing in all of n-card causes considerable css bloat.

This PR brings in just the styles that are used in n-concept.

(Longer term it does need a full rewrite, but doing this will decrease the css bundle size for streams by around 20%.