### PR TITLE
Add: Pa11y notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ n-concept comes with 3 decorators
 `concept-image` retrieves the image for the concept card. It requires the name of the taxonomy for the concept, and the list of articles in an array of objects called `items`, which should be in your data anyway.
 
 The decorator finds an image from the list of articles to be displayed, and if it cannot find one uses a default.
+
+##Pa11y
+`$ make a11y`: Serves page of demo components, on which it runs [Pa11y](http://pa11y.org/) accessibility tests (errors flagging up accessibility infringements), which will also be run as part of the Continuous Integration (CI) process.

--- a/README.md
+++ b/README.md
@@ -45,5 +45,10 @@ n-concept comes with 3 decorators
 
 The decorator finds an image from the list of articles to be displayed, and if it cannot find one uses a default.
 
+##Demo page
+`$ make demo`: Serves examples of the component locally (`http://localhost:5005`), using dummy data and in isolation from an app.
+
+This is done on a simple express app which renders a single demo page that calls the partials to exhibit, populating them with data from a fixture.
+
 ##Pa11y
 `$ make a11y`: Serves page of demo components, on which it runs [Pa11y](http://pa11y.org/) accessibility tests (errors flagging up accessibility infringements), which will also be run as part of the Continuous Integration (CI) process.


### PR DESCRIPTION
Addresses: https://github.com/Financial-Times/next-a11y/issues/71.

The demo app runs Pa11y as default so feels like it was intended that a `make demo` command would not be used here, or should that be implemented?