### PR TITLE
removes overflow: hidden

### DIFF
--- a/styles/_myft-card.scss
+++ b/styles/_myft-card.scss
@@ -61,7 +61,7 @@
 .card__myft-meta {
 	border-top: 1px solid rgba(getColorFor('myft'), 0.3);
 	margin-top: 10px;
-	overflow: hidden;
+	overflow: visible;
 	padding-top: 10px;
 }
 


### PR DESCRIPTION
Required for the outline focus styles to be visible on myft buttons 
See also: https://github.com/Financial-Times/n-myft-ui/pull/10

without:
![buttons-before](https://cloud.githubusercontent.com/assets/17549437/25669326/17932974-3021-11e7-8bad-7fd56133ed6f.gif)
with:
![buttons-after](https://cloud.githubusercontent.com/assets/17549437/25669335/1d7526c6-3021-11e7-81f6-023e6c00a139.gif)


